### PR TITLE
pointpats 2.5.5 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pointpats" %}
-{% set version = "2.5.2" %}
+{% set version = "2.5.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6be0be63c893b542d4b6b00609bb8378c38b58245c1cc53a95283500c3d4a663
+  sha256: 5af6ad0b689905f59037a6a7e4ba99ab4aafe8e088894032902c3e7f9c7e72b5
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: true  # [py<310]
+  skip: true  # [py<311]
 
 requirements:
   host:
@@ -22,13 +22,13 @@ requirements:
     - setuptools_scm >=6.2
   run:
     - python
-    - libpysal >=4.8
-    - geopandas >=0.12
-    - matplotlib-base >=3.6
-    - numpy >=1.24
-    - pandas >=1.4,!=1.5.0
-    - scipy >=1.10
-    - shapely >=2
+    - libpysal >=4.10
+    - geopandas >=1.0
+    - matplotlib-base >=3.9
+    - numpy >=1.26
+    - pandas >=2.2
+    - scipy >=1.12
+    - shapely >=2.1
 
 test:
   source_files:
@@ -36,13 +36,15 @@ test:
     - pointpats
   imports:
     - pointpats
+    - pointpats.quadrat_statistics
+    - pointpats.random
   requires:
     - pip
     - pytest
   commands:
     - pip check
-    - pytest -vv pointpats/tests
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -ra -vv pointpats/tests
 
 about:
   home: https://pysal.org


### PR DESCRIPTION
pointpats 2.5.5 

**Destination channel:** Defaults

### Links

- [PKG-13112]
- dev_url:        https://github.com/pysal/pointpats/tree/v2.5.5
- conda_forge:    https://github.com/conda-forge/pointpats-feedstock
- pypi:           https://pypi.org/project/pointpats/2.5.5
- pypi inspector: https://inspector.pypi.io/project/pointpats/2.5.5

### Explanation of changes:

- version: updated from 2.5.2 to 2.5.5
- skip: minimum Python version raised from 3.10 to 3.11
- run: updated minimum dependency versions
- abs.yaml: added ANACONDA_ROCKET_ENABLE_PY314: yes


[PKG-13112]: https://anaconda.atlassian.net/browse/PKG-13112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ