### PR TITLE
pointpats 2.6.0 (due to numpy 2.5.0)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "2.5.5" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -25,7 +25,12 @@ requirements:
     - libpysal >=4.10
     - geopandas >=1.0
     - matplotlib-base >=3.9
-    - numpy >=1.26
+    # >  raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
+    # E  AttributeError: module 'numpy' has no attribute 'row_stack'
+    # https://numpy.org/doc/stable/release/2.0.0-notes.html
+    # Alias np.row_stack has been deprecated. Use np.vstack directly.
+    # https://github.com/numpy/numpy/pull/24445
+    - numpy >=1.26,<2
     - pandas >=2.2
     - scipy >=1.12
     - shapely >=2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pointpats" %}
-{% set version = "2.5.5" %}
+{% set version = "2.6.0" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ source:
   sha256: 5af6ad0b689905f59037a6a7e4ba99ab4aafe8e088894032902c3e7f9c7e72b5
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   skip: true  # [py<311]
 
@@ -20,20 +20,19 @@ requirements:
     - pip
     - setuptools >=61.0
     - setuptools_scm >=6.2
+    - tomli
   run:
     - python
-    - libpysal >=4.10
-    - geopandas >=1.0
-    - matplotlib-base >=3.9
-    # >  raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
-    # E  AttributeError: module 'numpy' has no attribute 'row_stack'
-    # https://numpy.org/doc/stable/release/2.0.0-notes.html
-    # Alias np.row_stack has been deprecated. Use np.vstack directly.
-    # https://github.com/numpy/numpy/pull/24445
-    - numpy >=1.26,<2
-    - pandas >=2.2
-    - scipy >=1.12
+    - libpysal >=4.12
+    - geopandas >=1.1.0
+    - matplotlib-base >=3.10
+    - numpy >=2.0.0
+    - pandas >=2.3.0
+    - scipy >=1.14
     - shapely >=2.1
+  run_constrained:
+    - numba>=0.60
+    - scikit-learn>=1.5.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5af6ad0b689905f59037a6a7e4ba99ab4aafe8e088894032902c3e7f9c7e72b5
+  sha256: 6c21e0a03d9ad4ca0f62393f888842212580d99b828b4b68ddeb1929eac8bdf2
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5af6ad0b689905f59037a6a7e4ba99ab4aafe8e088894032902c3e7f9c7e72b5
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   skip: true  # [py<311]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: true  # [py<311]
+  skip: true  # [py<312]
 
 requirements:
   host:


### PR DESCRIPTION
pointpats 2.6.0

[PKG-16074](https://anaconda.atlassian.net/browse/PKG-16074)
[upstream](https://github.com/pysal/pointpats/tree/v2.6.0)

- Add new version

[PKG-16074]: https://anaconda.atlassian.net/browse/PKG-16074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ